### PR TITLE
Greenpoint barcode fixes

### DIFF
--- a/bagel/download.py
+++ b/bagel/download.py
@@ -31,6 +31,8 @@ def get_metadata(outfile: str) -> str:
             "ISBN": lambda x: str(x),
             "UPC": lambda x: str(x),
             "Description/summary": lambda x: x.replace("\n", " "),
+            "Adams St. Barcodes": lambda x: str(x),
+            "Greenpoint Barcodes": lambda x: str(x),
         },
     )
     df.to_csv(outfile, index=False)

--- a/bagel/ingest.py
+++ b/bagel/ingest.py
@@ -1,6 +1,6 @@
 import csv
-from typing import Generator
 from collections import namedtuple
+from typing import Generator
 
 Row = namedtuple(
     "Row",
@@ -30,6 +30,7 @@ Row = namedtuple(
         "content",
         "email",
         "adams_st_barcodes",
+        "greenpoint_barcodes",
     ],
 )
 
@@ -77,6 +78,7 @@ def form_data_reader(file: str) -> Generator:
             newutrecht_barcodes = str2list(row[11])
             windsor_barcodes = str2list(row[12])
             adams_st_barcodes = str2list(row[25])
+            greenpoint_barcodes = str2list(row[26])
             isbns = str2list(row[17])
             upcs = str2list(row[18])
             title = trim_string(row[2])
@@ -111,4 +113,5 @@ def form_data_reader(file: str) -> Generator:
                 content=content,
                 email=row[24],
                 adams_st_barcodes=adams_st_barcodes,
+                greenpoint_barcodes=greenpoint_barcodes,
             )

--- a/bagel/produce.py
+++ b/bagel/produce.py
@@ -306,6 +306,10 @@ def game_record(data, control_number, suppressed=True, status_code="-"):
         field = create_item_field("88abg", barcode, data.price, status_code)
         record.add_ordered_field(field)
 
+    for barcode in data.greenpoint_barcodes:
+        field = create_item_field("41abg", barcode, data.price, status_code)
+        record.add_ordered_field(field)
+
     # 949 command line
     if suppressed is True:
         opac_display_command = "b3=n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 from bagel.ingest import Row
 
 
@@ -30,4 +31,5 @@ def stub_row() -> Row:
         content="1 gameboard",
         email="foobar@email.com",
         adams_st_barcodes="34444666666666",
+        greenpoint_barcodes="34444777777777",
     )


### PR DESCRIPTION
Adds Greenpoint barcodes to appropriate locations in order to properly format them. These barcodes are now read as strings rather than floats.